### PR TITLE
Support "require" statements in glsl files

### DIFF
--- a/libs/color-picker/src/shaders/sourceMap.ts
+++ b/libs/color-picker/src/shaders/sourceMap.ts
@@ -1,0 +1,7 @@
+import fragment from "./fragment.glsl"
+import vertex from "./vertex.glsl"
+
+export default {
+  fragment,
+  vertex,
+}

--- a/libs/shared/src/lib/WebGLProgramBuilder.ts
+++ b/libs/shared/src/lib/WebGLProgramBuilder.ts
@@ -12,6 +12,55 @@ export class WebGLProgramBuilder {
     this.fragmentShader = this.createShader(fragmentShaderSource, gl.FRAGMENT_SHADER)
   }
 
+  /**
+   * Recursively builds a GLSL source string from a source map.
+   * The source code may contain `#require "filename";` statements to include other files.
+   * The source map is modified in-place to contain the full source code for each file.
+   *
+   * @param mutableSourceMap The source map to use. This will be modified in-place.
+   * @param sourceFile The file within the source map to build the source for.
+   * @returns The fully resolved GLSL source code for the given file.
+   */
+  public static buildGlslSource<K extends string>(mutableSourceMap: Record<K, string>, sourceFile: K): string {
+    const rawSource: string = mutableSourceMap[sourceFile]
+
+    const resolvedSource = rawSource.replace(
+      /((?:^|;)[\r\n\s]+)#require\s+"(.*)";/g,
+      (_, beforeRequire, requiredFile) => {
+        if (requiredFile === sourceFile) {
+          throw new Error(`Circular dependency detected for file '${sourceFile.toString()}'`)
+        }
+
+        if (requiredFile in mutableSourceMap) {
+          const requiredSource = WebGLProgramBuilder.buildGlslSource(mutableSourceMap, requiredFile)
+          return `${beforeRequire}${requiredSource}\n`
+        } else {
+          throw new Error(`Failed to resolve required file '${requiredFile}'`)
+        }
+      },
+    )
+
+    mutableSourceMap[sourceFile] = resolvedSource
+
+    return resolvedSource
+  }
+
+  public static createFromSourceMap<T extends string>(
+    gl: WebGLRenderingContext,
+    sourceMap: Readonly<Record<T, string>>,
+    vertexShaderSource: T,
+    fragmentShaderSource: T,
+  ): WebGLProgram {
+    const mutableSource = { ...sourceMap }
+
+    const builder = new WebGLProgramBuilder(
+      gl,
+      WebGLProgramBuilder.buildGlslSource(mutableSource, vertexShaderSource),
+      WebGLProgramBuilder.buildGlslSource(mutableSource, fragmentShaderSource),
+    )
+    return builder.createProgram()
+  }
+
   public static create(
     gl: WebGLRenderingContext,
     vertexShaderSource: string,

--- a/libs/shared/src/lib/WebGLProrgramBuilder.spec.ts
+++ b/libs/shared/src/lib/WebGLProrgramBuilder.spec.ts
@@ -1,0 +1,121 @@
+import { WebGLProgramBuilder } from "./WebGLProgramBuilder"
+import { describe, expect, it } from "vitest"
+
+const exampleSourceMap = {
+  requireAtStart: '#require "function";\nvoid main() {}\n',
+  requireInFunction: 'void main() {\n  #require "comment";\n  // etc\n}',
+  requireAtEnd: 'void main() {}\n#require "comment";\n',
+  onlyRequire: '#require "function";',
+  multipleRequires: '#require "function";\n#require "comment";\n',
+  requiresMissing: '#require "missing";\n',
+  chainedRequire: '//chained:\n#require "requireAtStart";\n',
+
+  requireSelf: '#require "requireSelf";\n',
+
+  parentCircularRequire: '#require "childCircularRequire";\n',
+  childCircularRequire: '#require "parentCircularRequire";\n',
+
+  function: "function foo() {}\n",
+  comment: "// this is a comment\n",
+} as const
+const expectedResolvedSourceMap = {
+  requireAtStart: "function foo() {}\n\nvoid main() {}\n",
+  requireInFunction: "void main() {\n  // this is a comment\n\n  // etc\n}",
+  multipleRequires: "function foo() {}\n// this is a comment\n\n",
+  onlyRequire: "function foo() {}\n",
+  requiresMissing: '#require "missing";\n',
+  chainedRequire: `//chained:\nfunction foo() {}\n\nvoid main() {}\n`,
+  requireAtEnd: "void main() {}\n// this is a comment\n\n",
+
+  function: "function foo() {}\n",
+  comment: "// this is a comment\n",
+} as const
+
+describe("WebGLProgramBuilder.buildGlslSource", () => {
+  it("should resolve #require lines at the start of a sourceMap", () => {
+    const sourceMap = {
+      ...exampleSourceMap,
+    }
+    const source = WebGLProgramBuilder.buildGlslSource(sourceMap, "requireAtStart")
+    expect(source, "resolved source").toBe(expectedResolvedSourceMap.requireAtStart)
+  })
+
+  it("should update the sourceMap in-place", () => {
+    const sourceMap = {
+      ...exampleSourceMap,
+    }
+    WebGLProgramBuilder.buildGlslSource(sourceMap, "requireAtStart")
+    expect(sourceMap.requireAtStart).toBe(expectedResolvedSourceMap.requireAtStart)
+  })
+
+  it("should resolve #require lines in the middle of a sourceMap", () => {
+    const sourceMap = {
+      ...exampleSourceMap,
+    }
+    const source = WebGLProgramBuilder.buildGlslSource(sourceMap, "requireInFunction")
+    expect(source, "resolved source").toBe(expectedResolvedSourceMap.requireInFunction)
+  })
+
+  it("should resolve #require lines at the end of a sourceMap", () => {
+    const sourceMap = {
+      ...exampleSourceMap,
+    }
+    const source = WebGLProgramBuilder.buildGlslSource(sourceMap, "requireAtEnd")
+    expect(source, "resolved source").toBe(expectedResolvedSourceMap.requireAtEnd)
+  })
+
+  it("should resolve #require lines in a sourceMap with no other content", () => {
+    const sourceMap = {
+      ...exampleSourceMap,
+    }
+    const source = WebGLProgramBuilder.buildGlslSource(sourceMap, "onlyRequire")
+    expect(source, "resolved source").toBe(expectedResolvedSourceMap.onlyRequire)
+  })
+
+  // Chained requires are not currently supported
+  it.todo("should handle chained #require statements", () => {
+    const sourceMap = {
+      ...exampleSourceMap,
+    }
+    const source = WebGLProgramBuilder.buildGlslSource(sourceMap, "chainedRequire")
+    expect(source, "resolved source").toBe(expectedResolvedSourceMap.chainedRequire)
+  })
+
+  it("should throw an error requested file is not in source map", () => {
+    const sourceMap = {
+      ...exampleSourceMap,
+    }
+    // @ts-expect-error
+    expect(() => WebGLProgramBuilder.buildGlslSource(sourceMap, "missing")).toThrow(
+      "Failed to resolve source file 'missing'",
+    )
+  })
+
+  it("should throw an error when a required file is not in the sourceMap", () => {
+    const sourceMap = {
+      ...exampleSourceMap,
+    }
+    expect(() => WebGLProgramBuilder.buildGlslSource(sourceMap, "requiresMissing")).toThrow(
+      "Failed to resolve source file 'missing'",
+    )
+  })
+
+  it("should throw an error when a required file is the same as the requesting file", () => {
+    const sourceMap = {
+      ...exampleSourceMap,
+    }
+    expect(() => WebGLProgramBuilder.buildGlslSource(sourceMap, "requireSelf")).toThrow(
+      "Circular dependency detected for file 'requireSelf'",
+    )
+  })
+
+  // currently this will throw a stack overflow error
+  it.todo("should throw an error when a required file has a circular dependency", () => {
+    const sourceMap = {
+      ...exampleSourceMap,
+    }
+    expect(() => WebGLProgramBuilder.buildGlslSource(sourceMap, "parentCircularRequire")).toThrow(
+      "Circular dependency detected for file 'parentCircularRequire'",
+    )
+  })
+})

--- a/libs/webgl/src/programs/LineDrawingProgram.ts
+++ b/libs/webgl/src/programs/LineDrawingProgram.ts
@@ -1,22 +1,21 @@
 import { WebGLProgramBuilder } from "@libs/shared"
-import positionVertexSource from "./shaders/position.vertex.glsl"
-import fragmentShaderSource from "./shaders/color.fragment.glsl"
 import { Color, BaseProgram } from "@libs/shared"
+import sourceMap from "./shaders/sourceMap"
 
 export class LineDrawingProgram extends BaseProgram {
   constructor(public readonly gl: WebGLRenderingContext) {
-    super(WebGLProgramBuilder.create(gl, positionVertexSource, fragmentShaderSource))
+    super(WebGLProgramBuilder.createFromSourceMap(gl, sourceMap, "position.vertex", "color.fragment"))
   }
 
   public syncCanvasSize(): typeof this {
     super.syncCanvasSize()
-    const canvasSize = this.gl.getUniformLocation(this.program, "canvasSize")
+    const canvasSize = this.gl.getUniformLocation(this.program, "uCanvasSize")
     this.gl.uniform2f(canvasSize, this.gl.canvas.width, this.gl.canvas.height)
     return this
   }
 
   public setColor(color: Color): LineDrawingProgram {
-    const colorLocation = this.gl.getUniformLocation(this.program, "color")
+    const colorLocation = this.gl.getUniformLocation(this.program, "uColor")
     if (!colorLocation) {
       throw new Error("Failed to get color location. Does the specified program have a 'color' uniform?")
     }
@@ -33,7 +32,7 @@ export class LineDrawingProgram extends BaseProgram {
 
     this.setColor(color)
 
-    const position = this.gl.getAttribLocation(this.program, "position")
+    const position = this.gl.getAttribLocation(this.program, "aPosition")
     this.gl.enableVertexAttribArray(position)
     this.gl.vertexAttribPointer(position, 2, this.gl.FLOAT, false, 0, 0)
 

--- a/libs/webgl/src/programs/shaders/bezier.vertex.glsl
+++ b/libs/webgl/src/programs/shaders/bezier.vertex.glsl
@@ -1,0 +1,9 @@
+uniform mat4 uMVPMatrix;
+attribute vec2 aPosition;
+
+#require "normalizeCoords";
+
+// todo: untested
+void main() {
+  gl_Position = uMVPMatrix * vec4(normalizeCoords(aPosition), 0.0, 1.0);
+}

--- a/libs/webgl/src/programs/shaders/color.fragment.glsl
+++ b/libs/webgl/src/programs/shaders/color.fragment.glsl
@@ -1,6 +1,6 @@
 precision mediump float;
-uniform vec4 color;
+uniform vec4 uColor;
 
 void main() {
-  gl_FragColor = color;
+  gl_FragColor = uColor;
 }

--- a/libs/webgl/src/programs/shaders/inc/normalizeCoords.glsl
+++ b/libs/webgl/src/programs/shaders/inc/normalizeCoords.glsl
@@ -1,0 +1,7 @@
+uniform vec2 uCanvasSize;
+
+vec2 normalizeCoords(vec2 coords) {
+  float x = coords.x / uCanvasSize.x * 2.0 - 1.0;
+  float y = coords.y / uCanvasSize.y * -2.0 + 1.0;
+  return vec2(x, y);
+}

--- a/libs/webgl/src/programs/shaders/position.vertex.glsl
+++ b/libs/webgl/src/programs/shaders/position.vertex.glsl
@@ -1,13 +1,7 @@
-attribute vec2 position;
+attribute vec2 aPosition;
 
-uniform vec2 canvasSize;
-
-vec2 normalizeCoords(vec2 coords) {
-  float x = coords.x / canvasSize.x * 2.0 - 1.0;
-  float y = coords.y / canvasSize.y * -2.0 + 1.0;
-  return vec2(x, y);
-}
+#require "normalizeCoords";
 
 void main() {
-  gl_Position = vec4(normalizeCoords(position), 0.0, 1.0);
+  gl_Position = vec4(normalizeCoords(aPosition), 0.0, 1.0);
 }

--- a/libs/webgl/src/programs/shaders/sourceMap.ts
+++ b/libs/webgl/src/programs/shaders/sourceMap.ts
@@ -1,0 +1,9 @@
+import positionVertexSource from "./position.vertex.glsl"
+import fragmentShaderSource from "./color.fragment.glsl"
+import normalizeCoords from "./inc/normalizeCoords.glsl"
+
+export default {
+  "position.vertex": positionVertexSource,
+  "color.fragment": fragmentShaderSource,
+  normalizeCoords,
+}

--- a/libs/webgl/src/programs/shaders/sourceMap.ts
+++ b/libs/webgl/src/programs/shaders/sourceMap.ts
@@ -1,9 +1,17 @@
 import positionVertexSource from "./position.vertex.glsl"
-import fragmentShaderSource from "./color.fragment.glsl"
+import colorFragmentSource from "./color.fragment.glsl"
+import bezierFragmentSource from "./bezier.vertex.glsl"
 import normalizeCoords from "./inc/normalizeCoords.glsl"
 
+/**
+ * A map of shader source code.
+ *
+ * The keys are the names of the files within the source map.
+ * Use the `WebGLProgramBuilder.buildGlslSource` method to recursively build the full source code for a given file.
+ */
 export default {
   "position.vertex": positionVertexSource,
-  "color.fragment": fragmentShaderSource,
+  "color.fragment": colorFragmentSource,
+  "bezier.vertex": bezierFragmentSource,
   normalizeCoords,
 }


### PR DESCRIPTION
another thing nobody asked for but it bugged me that there was no way to include from other files

a couple of things currently aren't suppored:

* Circular dependencies are not caught between parent/child (but an error is thrown if a file requires itself)
* Chained requires don't resolve