### PR TITLE
Adds layered canvas support

### DIFF
--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -22,7 +22,8 @@ main {
   padding: 1rem 0;
 }
 
-main canvas {
+main .drawing-canvas-container {
+  position: relative;
   border: 1px solid rgb(25, 25, 28);
   background-color: rgb(45, 45, 50);
   background-image: url("data:image/svg+xml,%3Csvg opacity='0.2' fill='black' xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpolygon fill-rule='evenodd' points='0,0 16,0 16,32 32,32 32,16 0,16' /%3E%3C/svg%3E");

--- a/libs/color-picker/src/lib/GradientColorProgram.ts
+++ b/libs/color-picker/src/lib/GradientColorProgram.ts
@@ -3,11 +3,15 @@ import fragmentSource from "../shaders/fragment.glsl"
 import vertexSource from "../shaders/vertex.glsl"
 
 export class GradientColorProgram extends BaseProgram {
-  constructor(public readonly gl: WebGLRenderingContext) {
-    super(WebGLProgramBuilder.create(gl, vertexSource, fragmentSource))
+  constructor(gl: WebGLRenderingContext) {
+    super(gl)
     this.useProgram().syncCanvasSize()
     this.gl.clearColor(1, 1, 1, 1)
     this.gl.clear(this.gl.COLOR_BUFFER_BIT)
+  }
+
+  protected createProgram(): WebGLProgram {
+    return WebGLProgramBuilder.create(this.gl, vertexSource, fragmentSource)
   }
 
   public syncCanvasSize(): typeof this {

--- a/libs/shared/src/lib/BaseProgram.ts
+++ b/libs/shared/src/lib/BaseProgram.ts
@@ -1,38 +1,146 @@
-export abstract class BaseProgram {
-  public program: WebGLProgram
-  protected currentGl: WebGLRenderingContext
+export interface BaseProgramContext<UniformNames extends string, AttributeNames extends string> {
+  gl: WebGLRenderingContext
+  program: WebGLProgram
+  uniforms: Record<UniformNames, WebGLUniformLocation>
+  attributes: Record<
+    AttributeNames,
+    {
+      location: number
+      buffer?: WebGLBuffer | null
+    }
+  >
+}
 
-  constructor(protected _gl: WebGLRenderingContext) {
-    this.currentGl = _gl
-    this.program = this.createProgram()
+export type AttributeInfo = {
+  location: number
+  buffer?: WebGLBuffer | null
+}
+
+export interface IBaseProgram {
+  useContext(context: WebGLRenderingContext): this
+  gl: WebGLRenderingContext
+  syncCanvasSize(): this
+  getCanvasSize(): { width: number; height: number }
+  checkError(): this
+  /**
+   * @deprecated
+   */
+  useProgram(): this
+}
+
+export abstract class BaseProgram<
+  UniformNames extends string,
+  AttributeNames extends string,
+  ExtendableContext extends BaseProgramContext<UniformNames, AttributeNames> = BaseProgramContext<
+    UniformNames,
+    AttributeNames
+  >,
+> implements IBaseProgram
+{
+  private contexts: ExtendableContext[] = []
+
+  constructor(private _currentContext: ExtendableContext) {
+    this.currentContext = _currentContext
   }
 
-  set gl(value: WebGLRenderingContext) {
-    this.currentGl = value
-    this.program = this.createProgram()
-    this.useProgram()
-  }
-
-  get gl(): WebGLRenderingContext {
-    return this.currentGl
-  }
-
-  protected abstract createProgram(): WebGLProgram
-
-  public useProgram(): typeof this {
-    this.gl.useProgram(this.program)
-    this.syncCanvasSize()
+  public useContext(context: WebGLRenderingContext): this {
+    this.currentContext = this.findOrCreateContext(context)
     return this
   }
 
-  public syncCanvasSize(): typeof this {
+  protected abstract createContext(context: WebGLRenderingContext, program: WebGLProgram): ExtendableContext
+
+  protected static makeBaseContextFromAttributes<UniformNames extends string, AttributeNames extends string>(
+    gl: WebGLRenderingContext,
+    program: WebGLProgram,
+    uniformNames: Record<UniformNames, string>,
+    attributeNames: Record<AttributeNames, string>,
+  ): BaseProgramContext<UniformNames, AttributeNames> {
+    const uniforms: Record<string, WebGLUniformLocation> = {}
+    const attributes: Record<string, AttributeInfo> = {}
+
+    for (const [key, value] of Object.entries(uniformNames)) {
+      uniforms[key] = BaseProgram._getUniformLocationOrThrow(value as string, gl, program)
+    }
+
+    for (const [key, value] of Object.entries(attributeNames)) {
+      attributes[key as AttributeNames] = {
+        location: gl.getAttribLocation(program, value as string),
+      }
+    }
+
+    return {
+      gl,
+      program,
+      uniforms: uniforms as Record<UniformNames, WebGLUniformLocation>,
+      attributes: attributes as Record<AttributeNames, AttributeInfo>,
+    }
+  }
+
+  public get gl(): WebGLRenderingContext {
+    if (!this.currentContext) {
+      throw new Error("No context is set")
+    }
+    return this.currentContext.gl
+  }
+
+  public set gl(gl: WebGLRenderingContext) {
+    this.useContext(gl)
+  }
+
+  protected get currentContext(): ExtendableContext {
+    if (!this._currentContext) {
+      throw new Error("No context is set")
+    }
+    return this._currentContext
+  }
+
+  private set currentContext(context: ExtendableContext) {
+    this._currentContext = context
+    context.gl.useProgram(context.program)
+  }
+
+  protected get program(): WebGLProgram {
+    if (!this.currentContext) {
+      throw new Error("No context is set")
+    }
+    return this.currentContext.program
+  }
+
+  private findContext(context: WebGLRenderingContext) {
+    return this.contexts.find(({ gl: ctx }) => ctx === context)
+  }
+
+  private findOrCreateContext(context: WebGLRenderingContext) {
+    const existingContext = this.findContext(context)
+    if (existingContext) {
+      return existingContext
+    }
+    const program = this.createProgram(context)
+    const newContext = this.createContext(context, program)
+    this.contexts.push(newContext)
+    return newContext
+  }
+
+  protected abstract createProgram(context: WebGLRenderingContext): WebGLProgram
+
+  /**
+   * @deprecated
+   */
+  protected useProgram(context = this.currentContext): this {
+    context.gl.useProgram(context.program)
+    this.syncCanvasSize(context)
+    return this
+  }
+
+  public syncCanvasSize(context = this.currentContext): typeof this {
     const { width, height } = this.getCanvasSize()
-    this.gl.viewport(0, 0, width, height)
+    context.gl.viewport(0, 0, width, height)
     return this
   }
 
-  public getCanvasSize(): { width: number; height: number } {
-    const canvas = this.gl.canvas
+  public getCanvasSize(context = this.currentContext): { width: number; height: number } {
+    const canvas = context.gl.canvas
     if (!(canvas instanceof HTMLElement)) {
       throw new Error("Could not get canvas size, canvas is not an HTMLCanvasElement")
     }
@@ -41,20 +149,74 @@ export abstract class BaseProgram {
     return { width: boundingRect.width, height: boundingRect.height }
   }
 
-  public createBuffer(target = this.gl.ARRAY_BUFFER): WebGLBuffer {
-    const buffer = this.gl.createBuffer()
-    if (!buffer) {
-      throw new Error("Failed to create buffer")
-    }
-    this.gl.bindBuffer(target, buffer)
-    return buffer
-  }
-
-  public checkError(): typeof this {
-    const error = this.gl.getError()
-    if (error !== this.gl.NO_ERROR) {
+  public checkError(context = this.currentContext): typeof this {
+    const error = context.gl.getError()
+    if (error !== WebGLRenderingContext.NO_ERROR) {
       throw new Error("WebGL error: " + error)
     }
     return this
+  }
+
+  protected getUniformLocation(name: UniformNames, context = this.currentContext): WebGLUniformLocation {
+    return context.uniforms[name]
+  }
+
+  protected getAttribute(attrName: AttributeNames, context = this.currentContext): AttributeInfo {
+    const attr = context.attributes[attrName]
+    if (!attr) {
+      throw new Error(`Attribute '${attrName.toString()}' does not exist`)
+    }
+    return attr
+  }
+
+  protected createBuffer(target = this.gl.ARRAY_BUFFER, context = this.currentContext): WebGLBuffer {
+    const buffer = context.gl.createBuffer()
+    if (!buffer) {
+      throw new Error("Failed to create buffer")
+    }
+    context.gl.bindBuffer(target, buffer)
+    return buffer
+  }
+
+  private static _getUniformLocationOrThrow(
+    name: string,
+    gl: WebGLRenderingContext,
+    program: WebGLProgram,
+  ): WebGLUniformLocation {
+    const uniformLocation = gl.getUniformLocation(program, name)
+    if (!uniformLocation) {
+      throw new Error(`Failed to get uniform location. Does the specified program have a '${name}' uniform?`)
+    }
+    return uniformLocation
+  }
+
+  protected bufferAttribute(
+    attrName: AttributeNames,
+    data: Readonly<Float32Array>,
+    {
+      usage,
+      size,
+      type = WebGLRenderingContext.FLOAT,
+      isNormalized = false,
+      stride = 0,
+      offset = 0,
+      context = this.currentContext,
+    }: {
+      usage: number
+      size: number
+      type?: number
+      isNormalized?: boolean
+      stride?: number
+      offset?: number
+      context?: ExtendableContext
+    },
+  ): void {
+    const attr = this.getAttribute(attrName, context)
+    if (!attr.buffer) {
+      attr.buffer = this.createBuffer(WebGLRenderingContext.ARRAY_BUFFER, context)
+    }
+    context.gl.bufferData(WebGLRenderingContext.ARRAY_BUFFER, data, usage)
+    context.gl.enableVertexAttribArray(attr.location)
+    context.gl.vertexAttribPointer(attr.location, size, type, isNormalized, stride, offset)
   }
 }

--- a/libs/shared/src/lib/BaseProgram.ts
+++ b/libs/shared/src/lib/BaseProgram.ts
@@ -1,7 +1,23 @@
 export abstract class BaseProgram {
-  public abstract readonly gl: WebGLRenderingContext
+  public program: WebGLProgram
+  protected currentGl: WebGLRenderingContext
 
-  constructor(public readonly program: WebGLProgram) {}
+  constructor(protected _gl: WebGLRenderingContext) {
+    this.currentGl = _gl
+    this.program = this.createProgram()
+  }
+
+  set gl(value: WebGLRenderingContext) {
+    this.currentGl = value
+    this.program = this.createProgram()
+    this.useProgram()
+  }
+
+  get gl(): WebGLRenderingContext {
+    return this.currentGl
+  }
+
+  protected abstract createProgram(): WebGLProgram
 
   public useProgram(): typeof this {
     this.gl.useProgram(this.program)

--- a/libs/webgl/src/WebDrawingApp.ts
+++ b/libs/webgl/src/WebDrawingApp.ts
@@ -5,22 +5,38 @@ import { Vec2 } from "@libs/shared"
 export class WebDrawingApp {
   public readonly canvas: HTMLCanvasElement
   public readonly engine: DrawingEngine
+  public readonly container: HTMLDivElement
 
   constructor(
+    /**
+     * Note: Pointer events within the root element have their default behavior prevented.
+     */
     private readonly root: HTMLElement,
     width: number,
     height: number,
     private pixelDensity = window.devicePixelRatio,
   ) {
-    this.canvas = document.createElement("canvas")
-    root.appendChild(this.canvas)
+    const { container, canvas } = WebDrawingApp.createElements()
+    this.container = container
+    this.canvas = canvas
     this.resizeCanvas(width, height)
+    root.appendChild(container)
 
     this.engine = new DrawingEngine(this.canvas, pixelDensity)
     this.engine.clearCanvas()
     this.engine.setColor(Color.WHITE)
 
     this.addEventListeners()
+  }
+  private static createElements() {
+    const container = document.createElement("div")
+    container.classList.add("drawing-canvas-container")
+    container.style.position = "relative"
+
+    const canvas = document.createElement("canvas")
+    container.appendChild(canvas)
+
+    return { container, canvas }
   }
 
   public setPixelDensity(pixelDensity: number) {
@@ -88,7 +104,7 @@ export class WebDrawingApp {
   }
 
   protected getCanvasPosition(event: Event): Vec2 {
-    const [x, y] = getEventPosition(event, this.canvas)
+    const [x, y] = getEventPosition(event, this.container)
     return [x * this.pixelDensity, y * this.pixelDensity]
   }
 }

--- a/libs/webgl/src/engine/BaseDrawingEngine.ts
+++ b/libs/webgl/src/engine/BaseDrawingEngine.ts
@@ -1,11 +1,11 @@
-import { BaseProgram } from "@libs/shared"
+import { IBaseProgram } from "@libs/shared"
 
 export abstract class BaseDrawingEngine<
-  Programs extends Record<never, BaseProgram>,
+  Programs extends Record<never, IBaseProgram>,
   ProgramKeys extends keyof Programs = keyof Programs,
 > {
   protected baseLayer: WebGLRenderingContext
-  protected currentProgram?: BaseProgram
+  protected currentProgram?: IBaseProgram
   private programs: Programs
 
   constructor(canvas: HTMLCanvasElement, programs: (gl: WebGLRenderingContext) => Programs) {
@@ -19,11 +19,9 @@ export abstract class BaseDrawingEngine<
 
   protected getProgram<T extends ProgramKeys>(name: T): Programs[T] {
     const program = this.programs[name]
-    const asBaseProgram = program as BaseProgram
-    if (this.currentProgram !== program) {
-      asBaseProgram.useProgram()
-      this.currentProgram = asBaseProgram
-    }
+    const asBaseProgram = program as IBaseProgram
+    this.currentProgram = asBaseProgram
+    asBaseProgram.useProgram()
     return program
   }
 }

--- a/libs/webgl/src/engine/BaseDrawingEngine.ts
+++ b/libs/webgl/src/engine/BaseDrawingEngine.ts
@@ -4,7 +4,7 @@ export abstract class BaseDrawingEngine<
   Programs extends Record<never, BaseProgram>,
   ProgramKeys extends keyof Programs = keyof Programs,
 > {
-  protected gl: WebGLRenderingContext
+  protected baseLayer: WebGLRenderingContext
   protected currentProgram?: BaseProgram
   private programs: Programs
 
@@ -13,7 +13,7 @@ export abstract class BaseDrawingEngine<
     if (!gl) {
       throw new Error("WebGL not supported")
     }
-    this.gl = gl
+    this.baseLayer = gl
     this.programs = programs(gl)
   }
 

--- a/libs/webgl/src/programs/LineDrawingProgram.ts
+++ b/libs/webgl/src/programs/LineDrawingProgram.ts
@@ -4,10 +4,14 @@ import sourceMap from "./shaders/sourceMap"
 
 export class LineDrawingProgram extends BaseProgram {
   constructor(
-    public readonly gl: WebGLRenderingContext,
+    gl: WebGLRenderingContext,
     public pixelDensity = 1,
   ) {
-    super(WebGLProgramBuilder.createFromSourceMap(gl, sourceMap, "position.vertex", "color.fragment"))
+    super(gl)
+  }
+
+  protected createProgram(): WebGLProgram {
+    return WebGLProgramBuilder.createFromSourceMap(this.gl, sourceMap, "position.vertex", "color.fragment")
   }
 
   public syncCanvasSize(): typeof this {

--- a/libs/webgl/src/programs/shaders/sourceMap.ts
+++ b/libs/webgl/src/programs/shaders/sourceMap.ts
@@ -8,8 +8,37 @@ import normalizeCoords from "./inc/normalizeCoords.glsl"
  * The keys are the names of the files within the source map.
  * Use the `WebGLProgramBuilder.buildGlslSource` method to recursively build the full source code for a given file.
  */
-export default {
+const sourceMap = {
   "position.vertex": positionVertexSource,
   "color.fragment": colorFragmentSource,
   normalizeCoords,
 }
+export default sourceMap
+
+type NameMap = Record<keyof typeof sourceMap, Record<string, string>>
+
+// would be neat if I could run something to generate the uniformNames and attributeNames objects from the sourceMap
+
+const includableScripts = {
+  normalizeCoords: {
+    source: normalizeCoords,
+    uniforms: {
+      canvasSize: "uCanvasSize",
+    },
+  },
+} as const
+
+export const uniformNames = {
+  "position.vertex": {
+    ...includableScripts.normalizeCoords.uniforms,
+  },
+  "color.fragment": {
+    color: "uColor",
+  },
+} as const satisfies Readonly<Partial<NameMap>>
+
+export const attributeNames = {
+  "position.vertex": {
+    position: "aPosition",
+  },
+} as const satisfies Readonly<Partial<NameMap>>


### PR DESCRIPTION
This updates the drawing engine to draw lines on an "active" layer (which re-draws on every animation frame as a line is being drawn), but then commit them to a static canvas that retains its buffer.

Some related updates:
* Added a list of contexts that we can attach to a program (for different layers)
* Adds an interface for moderate type-safety with glsl attributes within the BaseProgram and classes extending it

This should work fairly smoothly for switching from one canvas to another without much fuss. I might be getting too fancy, though.

These classes need unit tests.