### PR TITLE
Removes alpha channel from color class

### DIFF
--- a/libs/shared/src/lib/Color.spec.ts
+++ b/libs/shared/src/lib/Color.spec.ts
@@ -4,8 +4,8 @@ import { it, describe, expect } from "vitest"
 const testData: ReadonlyArray<{
   colorName: string
   colorObject: Color
-  rgbaArray: [number, number, number, number]
-  hslaArray: [number, number, number, number]
+  rgbArray: [number, number, number]
+  hslArray: [number, number, number]
   rgbString: string
   rgbaString: string
   hexString: string
@@ -15,158 +15,158 @@ const testData: ReadonlyArray<{
   {
     colorName: "Black",
     colorObject: Color.BLACK,
-    rgbaArray: [0, 0, 0, 255],
+    rgbArray: [0, 0, 0],
     rgbString: "rgb(0, 0, 0)",
     rgbaString: "rgba(0, 0, 0, 1)",
     hexString: "#000000",
     hslString: "hsl(0, 0%, 0%)",
-    hslaArray: [0, 0, 0, 1],
+    hslArray: [0, 0, 0],
     hslaString: "hsla(0, 0%, 0%, 1)",
   },
   {
     colorName: "White",
     colorObject: Color.WHITE,
-    rgbaArray: [255, 255, 255, 255],
+    rgbArray: [255, 255, 255],
     rgbString: "rgb(255, 255, 255)",
     rgbaString: "rgba(255, 255, 255, 1)",
     hexString: "#ffffff",
     hslString: "hsl(0, 0%, 100%)",
-    hslaArray: [0, 0, 100, 1],
+    hslArray: [0, 0, 100],
     hslaString: "hsla(0, 0%, 100%, 1)",
   },
   {
     colorName: "Red",
     colorObject: new Color(255, 0, 0),
-    rgbaArray: [255, 0, 0, 255],
+    rgbArray: [255, 0, 0],
     rgbString: "rgb(255, 0, 0)",
     rgbaString: "rgba(255, 0, 0, 1)",
     hexString: "#ff0000",
     hslString: "hsl(0, 100%, 50%)",
-    hslaArray: [0, 100, 50, 1],
+    hslArray: [0, 100, 50],
     hslaString: "hsla(0, 100%, 50%, 1)",
   },
   {
     colorName: "Orange",
     colorObject: new Color(255, 165, 0),
-    rgbaArray: [255, 165, 0, 255],
+    rgbArray: [255, 165, 0],
     rgbString: "rgb(255, 165, 0)",
     rgbaString: "rgba(255, 165, 0, 1)",
     hexString: "#ffa500",
     hslString: "hsl(39, 100%, 50%)",
-    hslaArray: [39, 100, 50, 1],
+    hslArray: [39, 100, 50],
     hslaString: "hsla(39, 100%, 50%, 1)",
   },
   {
     colorName: "Yellow",
     colorObject: new Color(255, 255, 0),
-    rgbaArray: [255, 255, 0, 255],
+    rgbArray: [255, 255, 0],
     rgbString: "rgb(255, 255, 0)",
     rgbaString: "rgba(255, 255, 0, 1)",
     hexString: "#ffff00",
     hslString: "hsl(60, 100%, 50%)",
-    hslaArray: [60, 100, 50, 1],
+    hslArray: [60, 100, 50],
     hslaString: "hsla(60, 100%, 50%, 1)",
   },
   {
     colorName: "Green",
     colorObject: new Color(0, 128, 0),
-    rgbaArray: [0, 128, 0, 255],
+    rgbArray: [0, 128, 0],
     rgbString: "rgb(0, 128, 0)",
     rgbaString: "rgba(0, 128, 0, 1)",
     hexString: "#008000",
     hslString: "hsl(120, 100%, 25%)",
-    hslaArray: [120, 100, 25, 1],
+    hslArray: [120, 100, 25],
     hslaString: "hsla(120, 100%, 25%, 1)",
   },
   {
     colorName: "Blue",
     colorObject: new Color(0, 0, 255),
-    rgbaArray: [0, 0, 255, 255],
+    rgbArray: [0, 0, 255],
     rgbString: "rgb(0, 0, 255)",
     rgbaString: "rgba(0, 0, 255, 1)",
     hexString: "#0000ff",
     hslString: "hsl(240, 100%, 50%)",
-    hslaArray: [240, 100, 50, 1],
+    hslArray: [240, 100, 50],
     hslaString: "hsla(240, 100%, 50%, 1)",
   },
   {
     colorName: "Indigo",
     colorObject: new Color(75, 0, 130),
-    rgbaArray: [75, 0, 130, 255],
+    rgbArray: [75, 0, 130],
     rgbString: "rgb(75, 0, 130)",
     rgbaString: "rgba(75, 0, 130, 1)",
     hexString: "#4b0082",
     hslString: "hsl(275, 100%, 25%)",
-    hslaArray: [275, 100, 25, 1],
+    hslArray: [275, 100, 25],
     hslaString: "hsla(275, 100%, 25%, 1)",
   },
   {
     colorName: "Violet",
     colorObject: new Color(238, 130, 238),
-    rgbaArray: [238, 130, 238, 255],
+    rgbArray: [238, 130, 238],
     rgbString: "rgb(238, 130, 238)",
     rgbaString: "rgba(238, 130, 238, 1)",
     hexString: "#ee82ee",
     hslString: "hsl(300, 76%, 72%)",
-    hslaArray: [300, 76, 72, 1],
+    hslArray: [300, 76, 72],
     hslaString: "hsla(300, 76%, 72%, 1)",
   },
   {
     colorName: "Brown",
     colorObject: new Color(165, 42, 42),
-    rgbaArray: [165, 42, 42, 255],
+    rgbArray: [165, 42, 42],
     rgbString: "rgb(165, 42, 42)",
     rgbaString: "rgba(165, 42, 42, 1)",
     hexString: "#a52a2a",
     hslString: "hsl(0, 59%, 41%)",
-    hslaArray: [0, 59, 41, 1],
+    hslArray: [0, 59, 41],
     hslaString: "hsla(0, 59%, 41%, 1)",
   },
   {
     colorName: "Gray",
     colorObject: new Color(128, 128, 128),
-    rgbaArray: [128, 128, 128, 255],
+    rgbArray: [128, 128, 128],
     rgbString: "rgb(128, 128, 128)",
     rgbaString: "rgba(128, 128, 128, 1)",
     hexString: "#808080",
     hslString: "hsl(0, 0%, 50%)",
-    hslaArray: [0, 0, 50, 1],
+    hslArray: [0, 0, 50],
     hslaString: "hsla(0, 0%, 50%, 1)",
   },
 ]
 
-const toStringResultType = "rgbaString"
+const toStringResultType = "rgbString"
 
 describe("Color", () => {
-  it("should create a color with RGBA values", () => {
+  it("should create a color with RGB values", () => {
     for (const {
       [toStringResultType]: toStringResult,
-      rgbaArray: [r, g, b, a],
+      rgbArray: [r, g, b],
     } of testData) {
-      const color = new Color(r, g, b, a)
+      const color = new Color(r, g, b)
       expect(color.toString()).toBe(toStringResult)
       expect(color.r).toBe(r)
       expect(color.g).toBe(g)
       expect(color.b).toBe(b)
-      expect(color.a).toBe(a)
     }
   })
 
-  it("should return an rgba string with toString", () => {
-    for (const { colorObject, rgbaString, colorName } of testData) {
-      expect(colorObject.toString(), colorName).toBe(rgbaString)
+  it("should return an rgb string with toString", () => {
+    for (const { colorObject, rgbString, colorName } of testData) {
+      expect(colorObject.toString(), colorName).toBe(rgbString)
     }
-    expect(toStringResultType).toBe("rgbaString")
+    expect(toStringResultType).toBe("rgbString")
   })
 
-  it("should return a Uint8ClampedArray with the vec4 parameter", () => {
-    expect(Color.WHITE.vec4).toBeInstanceOf(Uint8ClampedArray)
+  it("should return a Uint8ClampedArray of length 3 with the vec3 parameter", () => {
+    expect(Color.WHITE.vec3).toBeInstanceOf(Uint8ClampedArray)
+    expect(Color.WHITE.vec3).toHaveLength(3)
   })
 
   it("should return the red channel value with r", () => {
     for (const {
       colorObject,
-      rgbaArray: [r],
+      rgbArray: [r],
       colorName,
     } of testData) {
       expect(colorObject.r, colorName).toBe(r)
@@ -176,7 +176,7 @@ describe("Color", () => {
   it("should return the green channel value with g", () => {
     for (const {
       colorObject,
-      rgbaArray: [_, g],
+      rgbArray: [_, g],
       colorName,
     } of testData) {
       expect(colorObject.g, colorName).toBe(g)
@@ -186,46 +186,10 @@ describe("Color", () => {
   it("should return the blue channel value with b", () => {
     for (const {
       colorObject,
-      rgbaArray: [_, __, b],
+      rgbArray: [_, __, b],
       colorName,
     } of testData) {
       expect(colorObject.b, colorName).toBe(b)
-    }
-  })
-
-  it("should return the alpha channel value with a", () => {
-    for (const {
-      colorObject,
-      rgbaArray: [_, __, ___, a],
-      colorName,
-    } of testData) {
-      expect(colorObject.a, colorName).toBe(a)
-    }
-  })
-
-  it.each([0, 4, 25, 32, 50, 64, 100])("should be able to be generated with and return alpha at %i%", (alpha) => {
-    for (const {
-      colorName,
-      rgbaArray: [r, g, b],
-      hslaArray: [h, s, l],
-    } of testData) {
-      const a = (alpha / 100) * 255
-      const colorFromRgb = new Color(r, g, b, a)
-      expect(colorFromRgb.alphaPercent, `${colorName} from rgba`).toBe(alpha)
-      expect(Math.round(colorFromRgb.a), `${colorName} from rgba`).toBe(Math.round(a))
-      const colorFromHsla = new Color(`hsla(${h}, ${s}%, ${l}%, ${alpha / 100})`)
-      expect(colorFromHsla.alphaPercent, `${colorName} from hsla`).toBe(alpha)
-    }
-  })
-
-  it("should create a color with full opacity when opacity is not specified", () => {
-    for (const {
-      [toStringResultType]: toStringResult,
-      rgbaArray: [r, g, b],
-    } of testData) {
-      const color = new Color(r, g, b)
-      expect(color.toString()).toBe(toStringResult)
-      expect(color.a).toBe(255)
     }
   })
 
@@ -261,13 +225,12 @@ describe("Color", () => {
   it("should create a color from a Uint8ClampedArray", () => {
     for (const {
       colorName,
-      rgbaArray: [r, g, b, a],
+      rgbArray: [r, g, b],
     } of testData) {
-      const color = new Color(new Uint8ClampedArray([r, g, b, a]))
+      const color = new Color(new Uint8ClampedArray([r, g, b]))
       expect(color.r, colorName).toBe(r)
       expect(color.g, colorName).toBe(g)
       expect(color.b, colorName).toBe(b)
-      expect(color.a, colorName).toBe(a)
     }
   })
 
@@ -282,6 +245,5 @@ describe("Color", () => {
   it("should have the right colors for constant values", () => {
     expect(Color.BLACK.hex).toBe("#000000")
     expect(Color.WHITE.hex).toBe("#ffffff")
-    expect(Color.TRANSPARENT.rgba).toBe("rgba(0, 0, 0, 0)")
   })
 })

--- a/libs/shared/src/lib/Color.ts
+++ b/libs/shared/src/lib/Color.ts
@@ -1,75 +1,64 @@
 import { VectorArray } from "../types/arrays"
 
-export type RbgaArray = [
+export type RbgArray = [
   /** Red as an 8 bit number (0 to 255) */
   red: number,
   /** Green as an 8 bit number (0 to 255) */
   green: number,
   /** Blue as an 8 bit number (0 to 255) */
   blue: number,
-  /** Alpha as an 8 bit number (0 to 255) */
-  alpha: number,
 ]
-export type HslaArray = [
+export type HslArray = [
   /** Hue as a degree (0 to 360) */
   hue: number,
   /** Saturation as a percentage (0 to 100) */
   saturation: number,
   /** Lightness as a percentage (0 to 100) */
   lightness: number,
-  /** Alpha as a percentage (0 to 1) */
-  alpha: number,
 ]
 
 export class Color {
   static readonly BLACK = new Color(0, 0, 0)
   static readonly WHITE = new Color(255, 255, 255)
-  static readonly TRANSPARENT = new Color(0, 0, 0, 0)
   private vector: Uint8ClampedArray
 
   public constructor(colorString: string, _?: never, __?: never, ___?: never)
   public constructor(vector: Readonly<Uint8ClampedArray>, _?: never, __?: never, ___?: never)
-  public constructor(vector: Readonly<VectorArray<3 | 4>>, _?: never, __?: never, ___?: never)
+  public constructor(vector: Readonly<RbgArray>, _?: never, __?: never, ___?: never)
   public constructor(
     /** Red as an 8 bit number (0 to 255) */
-    r: number,
+    red: number,
     /** Green as an 8 bit number (0 to 255) */
-    g: number,
+    green: number,
     /** Blue as an 8 bit number (0 to 255) */
-    b: number,
-    /** Alpha as an 8 bit number (0 to 255). Defaults to 255. */
-    a?: number,
+    blue: number,
   )
   public constructor(
     firstParam: Readonly<VectorArray<3 | 4>> | Readonly<Uint8ClampedArray> | number | string,
     g: typeof firstParam extends number ? number : never,
     b: typeof firstParam extends number ? number : never,
-    a?: typeof firstParam extends number ? number | undefined : never,
   ) {
     if (firstParam instanceof Uint8ClampedArray) {
       const vector = firstParam
       this.vector = vector.copyWithin(4, 0, 3)
-      if (vector.length < 4) this.vector[3] = 255
       return
     }
 
-    this.vector = new Uint8ClampedArray(4)
+    this.vector = new Uint8ClampedArray(3)
 
     if (typeof firstParam === "number") {
       const r = firstParam
       this.vector[0] = r
       this.vector[1] = g ?? 0
       this.vector[2] = b ?? 0
-      this.vector[3] = a ?? 255
       return
     }
 
     if (typeof firstParam === "string") {
-      const color: RbgaArray = Color.fromString(firstParam)
+      const color: RbgArray = Color.fromString(firstParam)
       this.vector[0] = color[0]
       this.vector[1] = color[1]
       this.vector[2] = color[2]
-      this.vector[3] = color[3]
       return
     }
 
@@ -77,13 +66,12 @@ export class Color {
       this.vector[0] = firstParam[0]
       this.vector[1] = firstParam[1]
       this.vector[2] = firstParam[2]
-      this.vector[3] = firstParam[3] ?? 255
     }
 
     throw new Error("Invalid color parameters")
   }
 
-  get vec4(): Readonly<Uint8ClampedArray> {
+  get vec3(): Readonly<Uint8ClampedArray> {
     return this.vector
   }
 
@@ -109,40 +97,40 @@ export class Color {
   get b(): number {
     return this.vector[2]
   }
-  /**
-   * Alpha as an 8 bit number (0 to 255).
-   */
-  get a(): number {
-    return this.vector[3]
-  }
-  /**
-   * Alpha as an integer from 0 to 100.
-   */
-  get alphaPercent(): number {
-    return Math.round((this.a / 255) * 100)
-  }
 
   get rgb(): string {
     return `rgb(${this.r}, ${this.g}, ${this.b})`
   }
+
   get rgba(): string {
-    return `rgba(${this.r}, ${this.g}, ${this.b}, ${this.alphaPercent / 100})`
+    return this.getRgba()
   }
+
+  public getRgba(alphaPercent = 100): string {
+    return `rgba(${this.r}, ${this.g}, ${this.b}, ${alphaPercent / 100})`
+  }
+
   get hex(): string {
     const toHex = (n: number): string => n.toString(16).padStart(2, "0")
     return `#${toHex(this.r)}${toHex(this.g)}${toHex(this.b)}`
   }
+
   get hsl(): string {
     const [h, s, l] = this.getHslaValues()
     return `hsl(${Math.round(h)}, ${Math.round(s)}%, ${Math.round(l)}%)`
   }
+
   get hsla(): string {
-    const [h, s, l, a] = this.getHslaValues()
-    return `hsla(${Math.round(h)}, ${Math.round(s)}%, ${Math.round(l)}%, ${a})`
+    return this.getHsla()
+  }
+
+  public getHsla(alphaPercent = 100): string {
+    const [h, s, l] = this.getHslaValues()
+    return `hsla(${Math.round(h)}, ${Math.round(s)}%, ${Math.round(l)}%, ${alphaPercent / 100})`
   }
 
   public toString(): string {
-    return this.rgba
+    return this.rgb
   }
 
   /**
@@ -150,7 +138,7 @@ export class Color {
    * @returns An array of HSLA values.
    * @see https://en.wikipedia.org/wiki/HSL_and_HSV
    */
-  public getHslaValues(): HslaArray {
+  public getHslaValues(): HslArray {
     const redPercent = this.r / 255
     const greenPercent = this.g / 255
     const bluePercent = this.b / 255
@@ -159,7 +147,7 @@ export class Color {
     const min = Math.min(redPercent, greenPercent, bluePercent)
     const lightness = (max + min) / 2
 
-    if (max === min) return [0, 0, lightness * 100, this.a / 255]
+    if (max === min) return [0, 0, lightness * 100]
 
     const delta = max - min
     let hue = 0
@@ -181,7 +169,7 @@ export class Color {
 
     const saturation = lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min)
 
-    return [hue, saturation * 100, lightness * 100, this.a / 255]
+    return [hue, saturation * 100, lightness * 100]
   }
 
   public equals(color: Color): boolean {
@@ -192,7 +180,7 @@ export class Color {
     return true
   }
 
-  protected static fromString(color: string): RbgaArray {
+  protected static fromString(color: string): RbgArray {
     if (color.startsWith("#")) return Color.fromHex(color)
     if (color.startsWith("rgb(")) return Color.fromRgb(color)
     if (color.startsWith("rgba(")) return Color.fromRgba(color)
@@ -201,7 +189,7 @@ export class Color {
     throw new Error("Invalid color string")
   }
 
-  protected static fromHex(hex: string): RbgaArray {
+  protected static fromHex(hex: string): RbgArray {
     if (hex.length === 4) {
       const fullHex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`
       return this.fromHex(fullHex)
@@ -211,50 +199,44 @@ export class Color {
       .slice(1)
       .match(/.{2}/g)!
       .map((c) => parseInt(c, 16))
-    return [r, g, b, 255]
+    return [r, g, b]
   }
 
-  protected static fromRgb(rgb: string): RbgaArray {
+  protected static fromRgb(rgb: string): RbgArray {
     const [r, g, b] = rgb
       .slice(4, -1)
       .split(",")
       .map((c) => parseInt(c.trim()))
-    return [r, g, b, 255]
+    return [r, g, b]
   }
 
-  protected static fromRgba(rgba: string): RbgaArray {
+  protected static fromRgba(rgba: string): RbgArray {
     const sliced = rgba
       .slice(5, -1)
       .split(",")
       .map((s) => s.trim())
     const [r, g, b] = sliced.map((c) => parseInt(c))
-    const a = Color.parseAlphaString(sliced[3])
-    return [r, g, b, a * 255]
+    return [r, g, b]
   }
 
-  protected static fromHsl(hsl: string): RbgaArray {
+  protected static fromHsl(hsl: string): RbgArray {
     const [h, s, l] = hsl
       .slice(4, -1)
       .split(",")
       .map((c) => parseInt(c.trim()))
-    return Color.fromHslaValues(h, s, l)
+    return Color.fromHslValues(h, s, l)
   }
 
-  protected static fromHsla(hsla: string): RbgaArray {
+  protected static fromHsla(hsla: string): RbgArray {
     const sliced = hsla
       .slice(5, -1)
       .split(",")
       .map((s) => s.trim())
     const [h, s, l] = sliced.map((c) => parseInt(c))
-    return Color.fromHslaValues(h, s, l, parseFloat(sliced[3]))
+    return Color.fromHslValues(h, s, l)
   }
 
-  protected static parseAlphaString(alpha: string): number {
-    if (alpha.endsWith("%")) return parseFloat(alpha) / 100
-    return parseFloat(alpha)
-  }
-
-  protected static fromHslaValues(h: number, s: number, l: number, a = 1): RbgaArray {
+  protected static fromHslValues(h: number, s: number, l: number): RbgArray {
     const hue = h / 360
     const saturation = s / 100
     const lightness = l / 100
@@ -281,6 +263,6 @@ export class Color {
       blue = hueToColorValue(p, q, hue - 1 / 3)
     }
 
-    return [Math.round(red * 255), Math.round(green * 255), Math.round(blue * 255), a * 255]
+    return [Math.round(red * 255), Math.round(green * 255), Math.round(blue * 255)]
   }
 }

--- a/libs/webgl/src/engine/DrawingEngine.ts
+++ b/libs/webgl/src/engine/DrawingEngine.ts
@@ -18,6 +18,7 @@ interface HistoryItem {
 
 interface DrawingState {
   color: Color
+  opacity: number
   currentPath: LineInfo
   lineWeight: number
   isDrawing: boolean
@@ -60,6 +61,7 @@ export class DrawingEngine {
     this.state = {
       ...options,
       color: Color.BLACK,
+      opacity: 255,
       currentPath: { points: [] },
       lineWeight: 20,
       isDrawing: false,
@@ -126,18 +128,16 @@ export class DrawingEngine {
 
   public setColor(color: Color) {
     this.commitPath()
-    const opacity = this.state.color.a
-    this.state.color = new Color(color.r, color.g, color.b, opacity)
+    this.state.color = color
   }
 
   public setOpacity(opacity: number) {
     this.commitPath()
-    const color = this.state.color
-    this.state.color = new Color(color.r, color.g, color.b, opacity)
+    this.state.opacity = opacity
   }
 
   public getOpacity() {
-    return this.state.color.a
+    return this.state.opacity
   }
 
   public get lineWeight(): number {
@@ -156,7 +156,8 @@ export class DrawingEngine {
   protected getLineOptions(): Required<Omit<DrawLineOptions, "drawType">> {
     return {
       color: this.state.color,
-      thickness: this.lineWeight,
+      opacity: this.state.opacity,
+      diameter: this.lineWeight,
     }
   }
 

--- a/libs/webgl/src/programs/abstract/SimpleShaderProgram.ts
+++ b/libs/webgl/src/programs/abstract/SimpleShaderProgram.ts
@@ -32,7 +32,12 @@ export abstract class SimpleShaderProgram extends BaseProgram<
   }
 
   protected setColor(color: Color): typeof this {
-    this.gl.uniform4fv(this.getUniformLocation("color"), color.vec4)
+    this.gl.uniform3fv(this.getUniformLocation("color"), color.vec3)
+    return this
+  }
+
+  protected setOpacity(opacity: number): typeof this {
+    this.gl.uniform1f(this.getUniformLocation("opacity"), opacity)
     return this
   }
 

--- a/libs/webgl/src/programs/shaders/color.fragment.glsl
+++ b/libs/webgl/src/programs/shaders/color.fragment.glsl
@@ -1,6 +1,7 @@
 precision mediump float;
-uniform vec4 uColor;
+uniform vec3 uColor;
+uniform float uOpacity;
 
 void main() {
-  gl_FragColor = uColor / vec4(255.0);
+  gl_FragColor = vec4(uColor, uOpacity) / vec4(255.0);
 }

--- a/libs/webgl/src/programs/shaders/sourceMap.ts
+++ b/libs/webgl/src/programs/shaders/sourceMap.ts
@@ -38,6 +38,7 @@ export const uniformNames = {
   },
   "color.fragment": {
     color: "uColor",
+    opacity: "uOpacity",
   },
   "texture.fragment": {
     texture: "uTexture",


### PR DESCRIPTION
I removed the alpha channel from the color class, since the color picker doesn't need to handle alpha. Opacity is now handled as its own state value.