### PR TITLE
Adds a touch event for changing opacity/line weight

### DIFF
--- a/apps/web/src/components/EditableNumericLabel.tsx
+++ b/apps/web/src/components/EditableNumericLabel.tsx
@@ -79,6 +79,25 @@ export function EditableNumericLabel(props: {
     props.onChange(value)
   }
 
+  let lastTouchY: number | null = null
+  const handleTouchMove = (e: TouchEvent) => {
+    e.preventDefault()
+    if (lastTouchY === null) {
+      lastTouchY = e.touches[0].clientY
+      return
+    }
+    if (e.touches[0].clientY > lastTouchY) {
+      props.onChange((value) => value - 1)
+    } else {
+      props.onChange((value) => value + 1)
+    }
+    lastTouchY = e.touches[0].clientY
+  }
+
+  const handleTouchEnd = () => {
+    lastTouchY = null
+  }
+
   return (
     <span
       style={{ caretColor: "currentColor" }}
@@ -89,6 +108,8 @@ export function EditableNumericLabel(props: {
       onWheel={handleScrollWheel}
       onPaste={handlePaste}
       onBlur={handleBlur}
+      onTouchEnd={handleTouchEnd}
+      onTouchMove={handleTouchMove}
     >
       {props.displayValue}
     </span>


### PR DESCRIPTION
It's tedious to have to type numbers for these on mobile, and the sliders themselves are a bit too large for the UI. This adds  the ability to change the opacity or line weight by touching and dragging up or down on the number.