### PR TITLE
Sets the color  marker position from event

### DIFF
--- a/libs/color-picker/src/lib/ValueSaturationGradientColorProgram.ts
+++ b/libs/color-picker/src/lib/ValueSaturationGradientColorProgram.ts
@@ -7,6 +7,7 @@ const UNIFORM_NAMES = {
   uResolution: "uResolution",
   uHue: "uHue",
   uSelectedColor: "uSelectedColor",
+  uMarkerPosition: "uMarkerPosition",
 } as const
 const ATTRIBUTE_NAMES = {
   aPosition: "aPosition",
@@ -18,6 +19,8 @@ export class ValueSaturationGradientColorProgram extends BaseGradientColorProgra
 > {
   private hue: number = 0
   private selectedColor?: Color
+  private markerPosition?: [x: number, y: number]
+
   constructor(gl: WebGLRenderingContext) {
     const program = ValueSaturationGradientColorProgram.createProgramStatic(gl)
     const programInfo = ValueSaturationGradientColorProgram.createProgramInfoStatic(gl, program)
@@ -40,13 +43,14 @@ export class ValueSaturationGradientColorProgram extends BaseGradientColorProgra
     return ValueSaturationGradientColorProgram.createProgramInfoStatic(context, program)
   }
 
-  public draw(hue?: number, selectedColor?: Color) {
+  public draw(hue?: number, selectedColor?: Color, markerPosition?: [x: number, y: number]) {
     if (selectedColor && selectedColor.saturation > 0) {
       this.hue = selectedColor.hue
     } else if (hue !== undefined) {
       this.hue = hue
     }
     this.selectedColor = selectedColor
+    this.markerPosition = markerPosition
 
     super.draw()
   }
@@ -54,6 +58,7 @@ export class ValueSaturationGradientColorProgram extends BaseGradientColorProgra
   protected setUniforms() {
     this.gl.uniform1f(this.getUniformLocation("uHue"), this.hue)
     this.gl.uniform3fv(this.getUniformLocation("uSelectedColor"), this.selectedColor?.vec3 ?? [-1, -1, -1])
+    this.gl.uniform2fv(this.getUniformLocation("uMarkerPosition"), this.markerPosition ?? [-1, -1])
   }
 
   public setHue(hue: number) {

--- a/libs/shared/src/lib/Color.ts
+++ b/libs/shared/src/lib/Color.ts
@@ -16,6 +16,14 @@ export type HslArray = [
   /** Lightness as a percentage (0 to 100) */
   lightness: number,
 ]
+export type HsvArray = [
+  /** Hue as a degree (0 to 360) */
+  hue: number,
+  /** Saturation as a percentage (0 to 100) */
+  saturation: number,
+  /** Value as a percentage (0 to 100) */
+  value: number,
+]
 
 export class Color {
   static readonly BLACK = new Color(0, 0, 0)
@@ -193,6 +201,40 @@ export class Color {
     const saturation = lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min)
 
     return [hue, saturation * 100, lightness * 100]
+  }
+
+  public getHsvValues(): HsvArray {
+    const redPercent = this.r / 255
+    const greenPercent = this.g / 255
+    const bluePercent = this.b / 255
+
+    const max = Math.max(redPercent, greenPercent, bluePercent)
+    const min = Math.min(redPercent, greenPercent, bluePercent)
+    const value = max
+
+    if (max === min) return [0, 0, value * 100]
+
+    const delta = max - min
+    let hue = 0
+    switch (max) {
+      case redPercent:
+        hue = ((greenPercent - bluePercent) / delta) % 6
+        break
+      case greenPercent:
+        hue = (bluePercent - redPercent) / delta + 2
+        break
+      case bluePercent:
+        hue = (redPercent - greenPercent) / delta + 4
+        break
+    }
+    hue *= 60
+    if (hue < 0) {
+      hue += 360
+    }
+
+    const saturation = max === 0 ? 0 : delta / max
+
+    return [hue, saturation * 100, value * 100]
   }
 
   public equals(color: Color): boolean {


### PR DESCRIPTION
Instead of always calculating it from the color. This fixes an issue where the marker jumps around when selecting near-black colors.

Some of the logic for when to set the marker position or not is kind of messy, but I'm not in a state right now to address it and it seems to be working alright.