### PR TITLE
Adds an undo/redo tool

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -68,6 +68,12 @@ function main() {
       link.href = url
       link.click()
     },
+    onUndo() {
+      engine.undo()
+    },
+    onRedo() {
+      engine.redo()
+    },
     tools: tools,
     initialTool: engine.getCurrentToolName(),
 
@@ -102,6 +108,9 @@ function makeToolbar<T extends string>(
     onSetTool: (tool: T) => void
     onExport: (name: string) => void
     onLoadImage: (image: HTMLImageElement) => void
+
+    onUndo: () => void
+    onRedo: () => void
 
     addListener: WebDrawingEngine["addListener"]
   },
@@ -224,6 +233,39 @@ function makeToolbar<T extends string>(
     options.onExport(`${filename || "drawing"}.png`)
   })
   inputTray.append(exportButton)
+
+  const undoButton = document.createElement("button")
+  const redoButton = document.createElement("button")
+  undoButton.classList.add("undo-button")
+  redoButton.classList.add("redo-button")
+  undoButton.innerText = "Undo"
+  redoButton.innerText = "Redo"
+  undoButton.disabled = true
+  redoButton.disabled = true
+  inputTray.append(undoButton)
+  inputTray.append(redoButton)
+  undoButton.addEventListener("click", (e) => {
+    e.preventDefault()
+    options.onUndo()
+  })
+  redoButton.addEventListener("click", (e) => {
+    e.preventDefault()
+    options.onRedo()
+  })
+  options.addListener("draw", () => {
+    undoButton.disabled = false
+    redoButton.disabled = true
+  })
+  options.addListener("undo", ({ undosLeft }) => {
+    console.log({ undosLeft })
+    undoButton.disabled = undosLeft === 0
+    redoButton.disabled = false
+  })
+  options.addListener("redo", ({ redosLeft }) => {
+    console.log({ redosLeft })
+    undoButton.disabled = false
+    redoButton.disabled = redosLeft === 0
+  })
 
   const clearButton = document.createElement("button")
   clearButton.classList.add("clear-button")

--- a/libs/drawing-engine/src/engine/CanvasHistory.ts
+++ b/libs/drawing-engine/src/engine/CanvasHistory.ts
@@ -1,0 +1,141 @@
+import { LineDrawInfo } from "../tools/LineTool"
+import { EyeDropperInfo } from "../tools/EyeDropperTool"
+import { DrawingEngine } from "./DrawingEngine"
+
+type ToolInfo = LineDrawInfo | EyeDropperInfo
+
+export interface HistoryState {
+  toolInfo: ToolInfo
+  imageData: string | null
+}
+
+interface HistoryOptions {
+  maxHistory: number
+}
+
+export class CanvasHistory {
+  protected redoHistory: Array<Readonly<HistoryState>> = []
+  protected history: Array<Readonly<HistoryState>> = []
+  protected hasTruncated = false
+
+  constructor(
+    protected readonly engine: DrawingEngine,
+    protected options: HistoryOptions,
+  ) {
+    if (!options.maxHistory || options.maxHistory < 1) {
+      options.maxHistory = 10
+    }
+  }
+
+  public setOptions(options: Partial<HistoryOptions>) {
+    this.options = {
+      ...this.options,
+      ...options,
+    }
+    return this
+  }
+
+  public getOptions(): Readonly<HistoryOptions> {
+    return this.options
+  }
+
+  protected async getBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+    return new Promise((resolve) => {
+      canvas.toBlob((blob) => {
+        if (!blob) {
+          throw new Error("Could not get blob from canvas")
+        }
+        resolve(blob)
+      })
+    })
+  }
+
+  public save(toolInfo: ToolInfo) {
+    const canvas = this.engine.gl.canvas
+    if (!(canvas instanceof HTMLCanvasElement)) {
+      throw new Error("Canvas is not an HTMLCanvasElement")
+    }
+    const tool = this.engine.tools[toolInfo.tool]
+    if (!tool) {
+      throw new Error(`Tool ${toolInfo.tool} not found`)
+    }
+    this.addHistory({
+      toolInfo,
+      imageData: tool.updatesImageData ? canvas.toDataURL() : null,
+    })
+  }
+
+  public async redo() {
+    const state = this.redoHistory.pop()
+    if (!state) {
+      return
+    }
+    this.history.push(state)
+    return await this.drawState(state)
+  }
+
+  public async undo() {
+    const state = this.history.pop()
+    console.log("Undoing", state)
+    if (!state) {
+      return
+    }
+    const currentState = this.history[this.history.length - 1]
+    this.redoHistory.push(state)
+    return await this.drawState(currentState)
+  }
+
+  protected addHistory(state: HistoryState) {
+    console.log("Adding history", state)
+    if (this.history.length >= this.options.maxHistory) {
+      this.hasTruncated = true
+      this.history.shift()
+    }
+    this.history.push(state)
+    this.redoHistory = []
+  }
+
+  protected drawState(state: Readonly<HistoryState> | null) {
+    if (!state) {
+      if (!this.hasTruncated) this.engine.clearCanvas()
+      return Promise.resolve(null)
+    }
+    const { toolInfo, imageData } = state
+    console.log("Drawing state", state)
+    if (!imageData) {
+      return Promise.resolve(toolInfo)
+    }
+    return new Promise<HistoryState["toolInfo"]>((resolve, reject) => {
+      const image = new Image()
+      image.onload = () => {
+        this.engine._clear()
+        this.engine.loadImage(image)
+        resolve(toolInfo)
+      }
+      image.src = imageData
+      image.onerror = () => {
+        reject(new Error("Could not load image"))
+      }
+    })
+  }
+
+  public clear() {
+    this.history = []
+  }
+
+  public getHistory(): Readonly<{ undo: ReadonlyArray<HistoryState>; redo: ReadonlyArray<HistoryState> }> {
+    return {
+      undo: this.history,
+      redo: this.redoHistory,
+    }
+  }
+
+  public canUndo() {
+    const minStates = this.hasTruncated ? 1 : 0
+    return this.history.length > minStates
+  }
+
+  public canRedo() {
+    return this.redoHistory.length > 0
+  }
+}

--- a/libs/drawing-engine/src/engine/DrawingEngine.ts
+++ b/libs/drawing-engine/src/engine/DrawingEngine.ts
@@ -7,7 +7,7 @@ import { SourceImage } from "../utils/image/SourceImage"
 import { ToolName, ToolNames } from "../exports"
 import { LineDrawInfo, LineTool } from "../tools/LineTool"
 import { InputPoint } from "../tools/InputPoint"
-import { EyeDropperInfo, EyeDropperTool } from "../tools/EyeDropperTool"
+import { EyeDropperTool } from "../tools/EyeDropperTool"
 import { CanvasHistory, HistoryState } from "./CanvasHistory"
 
 interface DrawingEngineState {
@@ -27,7 +27,7 @@ export interface DrawingEngineOptions {
   pixelDensity?: number
 }
 
-type ToolInfo = LineDrawInfo | EyeDropperInfo
+type ToolInfo = LineDrawInfo
 
 export interface DrawingEngineEventMap {
   draw: ToolInfo
@@ -287,11 +287,6 @@ export class DrawingEngine {
     if (!toolInfo) {
       return
     }
-    if (toolInfo.tool === "eyedropper" && "previousColor" in toolInfo) {
-      this.setColor(toolInfo.previousColor.copy())
-    } else {
-      this.setTool(toolInfo.tool)
-    }
     const undosLeft = this.history.getHistory().undo.length
     this.callListeners("undo", { toolInfo, undosLeft })
   }
@@ -300,11 +295,6 @@ export class DrawingEngine {
     const toolInfo = await this.history.redo()
     if (!toolInfo) {
       return
-    }
-    if (toolInfo.tool === "eyedropper" && "color" in toolInfo) {
-      this.setColor(toolInfo.color.copy())
-    } else {
-      this.setTool(toolInfo.tool)
     }
     const redosLeft = this.history.getHistory().redo.length
     this.callListeners("redo", { toolInfo, redosLeft })

--- a/libs/drawing-engine/src/tools/EyeDropperTool.ts
+++ b/libs/drawing-engine/src/tools/EyeDropperTool.ts
@@ -69,14 +69,8 @@ export class EyeDropperTool {
     if (!color) {
       return false
     }
-    const previousColor = this.engine.getCurrentColor()
     this.engine.setColor(color)
     this.engine.callListeners("pickColor", { color })
-    this.engine.addHistory({
-      tool: this.toolName,
-      color,
-      previousColor,
-    })
     return true
   }
 }

--- a/libs/drawing-engine/src/tools/EyeDropperTool.ts
+++ b/libs/drawing-engine/src/tools/EyeDropperTool.ts
@@ -3,13 +3,14 @@ import { DrawingEngine, DrawingEngineEvent } from "../engine/DrawingEngine"
 import { InputPoint } from "./InputPoint"
 import { ToolNames } from "./Tools"
 
-export type EyeDropperHistoryEntry = {
+export type EyeDropperInfo = {
   tool: "eyedropper"
   color: Readonly<Color>
   previousColor: Readonly<Color>
 }
 
 export class EyeDropperTool {
+  public readonly updatesImageData = false
   public static readonly TOOL_NAME = ToolNames.eyedropper
   public readonly toolName = EyeDropperTool.TOOL_NAME
   constructor(public readonly engine: DrawingEngine) {
@@ -68,8 +69,14 @@ export class EyeDropperTool {
     if (!color) {
       return false
     }
+    const previousColor = this.engine.getCurrentColor()
     this.engine.setColor(color)
     this.engine.callListeners("pickColor", { color })
+    this.engine.addHistory({
+      tool: this.toolName,
+      color,
+      previousColor,
+    })
     return true
   }
 }

--- a/libs/drawing-engine/src/tools/LineTool.ts
+++ b/libs/drawing-engine/src/tools/LineTool.ts
@@ -3,13 +3,14 @@ import { DrawLineOptions, LineDrawingProgram } from "../programs/LineDrawingProg
 import { DrawingEngine, DrawingEngineEvent } from "../engine/DrawingEngine"
 import { ToolName } from "./Tools"
 
-export type LineHistoryEntry = {
+export type LineDrawInfo = {
   tool: ToolName
   path: InputPoint[]
   options: Required<Omit<DrawLineOptions, "drawType">>
 }
 
 export class LineTool {
+  public readonly updatesImageData = true
   private currentPath: InputPoint[] = []
   private options = {
     pressureEnabled: true,
@@ -90,11 +91,11 @@ export class LineTool {
       return
     }
     this.engine.commitToSavedLayer()
-    this.engine.addHistory(this.getHistoryEntry())
+    this.engine.addHistory(this.getToolInfo())
     this.currentPath = []
   }
 
-  private getHistoryEntry(): LineHistoryEntry {
+  private getToolInfo(): LineDrawInfo {
     return {
       path: structuredClone(this.currentPath),
       options: this.getLineOptions(),
@@ -116,7 +117,7 @@ export class LineTool {
         },
         this.getLineOptions(),
       )
-      return this.getHistoryEntry()
+      return this.getToolInfo()
     })
   }
 


### PR DESCRIPTION
The "clear" button doesn't create a history entry yet, so undoing will go to the state before the clear.

I've limited the history states to a max of 10 for now, since this is not a very memory-efficient way to keep track of history.

Closes #23